### PR TITLE
Pipx instead of pip to resolve dependency issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Contributions are welcomed!
 You can also install the latest version on GitHub
 
 ```bash
-pip install git+https://github.com/FrancescoSaverioZuppichini/my-spaces
+pipx install git+https://github.com/FrancescoSaverioZuppichini/my-spaces
 ```
+
+Install using pipx into an isolated environment to avoid dependency issues.
 
 TODO
 


### PR DESCRIPTION
With pip:
```
TypeError: load_config() got an unexpected keyword argument 'config_dict'
```

With pipx:

```
INFO:root:🔨 Building my-spaces:Youtube-Whisperer ...
```